### PR TITLE
Add option to generate applied_degradations.txt file

### DIFF
--- a/Dataset Destroyer/config.ini
+++ b/Dataset Destroyer/config.ini
@@ -10,7 +10,10 @@ degradations = blur,noise,compression,scale
 randomize = True
 # Whether to print the degradations applied onto the image. Useful for testing.
 print = False
-
+# Wheter to print the degradations applied into a separate text file. Useful for dataset statistics.
+textfile = False
+# The path where the applied_degradations.txt text file will be generated (or appended to if exists), use if textfile = True
+textfile_path = path/to/output
 
 # Blur settings
 [blur]


### PR DESCRIPTION
Adds the code and the option to output all the degradations that were applied to the images in the dataset in a separate text file called "applied_degradations.txt". In the config, this can be turned on, and also the folder path can be supplied to where this text file will be generated. If the file does not exist, it will be generated. But if for some reason this file already exists, it will not be deleted but rather the output will be appended in the text file. Tested on Ubuntu 22 and Windows 10.